### PR TITLE
ADD: 로컬스토리지로 방문 기록 관리 기능 추가

### DIFF
--- a/src/Pages/Admin/Admin.js
+++ b/src/Pages/Admin/Admin.js
@@ -6,7 +6,7 @@ const Admin = () => {
   const [cars, setCars] = useState([]);
 
   useEffect(() => {
-    fetch("/Data/Hani/adminData.json", {
+    fetch("/car/myCars", {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/src/Pages/Login/Login.js
+++ b/src/Pages/Login/Login.js
@@ -1,14 +1,19 @@
 // modules
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 //styles
 import styled from "styled-components";
+import moment from "moment";
+
 function Login() {
   const navigate = useNavigate();
   const [id, setId] = useState("");
   const [isLogin, setLogin] = useState(false);
+  //방문 기록이 있는지 관리하는 상태값
+  const [hasQuote, setHasQuote] = useState(false);
 
   const currentUser = localStorage.getItem("user");
+
   localStorage.setItem(
     "user",
     JSON.stringify({
@@ -19,6 +24,35 @@ function Login() {
       option: [1, 2, 3],
     })
   );
+
+  //방문 기록 확인 및 관리하는 함수
+  const checkExpiry = () => {
+    const timeStamp = localStorage.getItem("time_stamp");
+    //  timeStamp에서 시간과 분을 나눈다.
+    const month = moment().month();
+    const hour = moment().hour();
+    const date = moment().date();
+    //timestamp가 없는 경우
+    if (!timeStamp) {
+      localStorage.setItem(
+        "time_stamp",
+        JSON.stringify({
+          month: month,
+          date: date,
+          hour: hour,
+        })
+      );
+      return false;
+    } else {
+      const saved = localStorage.getItem("time_stamp");
+      const isExpired =
+        month >= saved.month && date > saved.date && hour > saved.hour;
+      if (isExpired) {
+        localStorage.clear();
+        return false;
+      } else return true;
+    }
+  };
 
   const handleInput = (e) => {
     let ret = isValidId(e.target.value);
@@ -41,6 +75,13 @@ function Login() {
     let ret = regId.test(str);
     return ret;
   }
+
+  useEffect(() => {
+    const isVisited = checkExpiry();
+    const isWriting = localStorage.length > 2;
+    const result = isVisited && isWriting;
+    setHasQuote(result);
+  }, []);
   return (
     <LoginBox>
       <LoginWrap>

--- a/src/Pages/Sellcar/AddInfo.js
+++ b/src/Pages/Sellcar/AddInfo.js
@@ -151,8 +151,10 @@ const AddInfo = () => {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem("image", JSON.stringify(carUrlImages));
-  }, [carUrlImages]);
+    if (carImages.length !== 0) {
+      localStorage.setItem("image", JSON.stringify(carImages));
+    }
+  }, [carImages]);
 
   useEffect(() => {
     if (carImages.length > 4) {


### PR DESCRIPTION
## 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 디자인

<br />

## 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. localStorage에 처음 접속한 시간(타임스탬프)을 저장
2. 다음 방문 때 타임스탬프와 방문한 시간을 비교한다.
3. 하루가 지나지 않았고 아직 localStorage에 추가 정보를 입력한 데이터가 있다면 hasQuote(작성중인 견적서가 있는지 관리하는 상태값)를 true로 설정


## :: 기타 질문 및 특이 사항

- 상태값 관리까지만 기능을 구현했고 상태값을 통해 조건부 렌더링하는 건 Annie님이 해주실 예정입니다.